### PR TITLE
Fix/update requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ Flask-Migrate
 Flask-Moment
 Flask-SQLAlchemy
 Flask-WTF
+gunicorn
 Jinja2
 PyJWT
 python-dotenv
 pytz
-requirements
 SQLAlchemy
 Werkzeug
 WTForms


### PR DESCRIPTION
There is no actual `requirements` Python library, so it is removed.
The `gunicorn` Python library was missing and is added.